### PR TITLE
#52 - add GR 12 - disable public marketplace organization policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 This repository will host the required tooling for deploying a basic GCP environment to be conformant with the the Government of Canada's [Cloud Guardrails Framework](https://github.com/canada-ca/cloud-guardrails).
 
-The deployment terraform files used to deploy the environments are location in the [deployment folder](https://github.com/canada-ca/accelerators_accelerateurs-gcp/tree/main/deployment-templates/Terraform/guardrails/) and are based off of the [example organization](https://github.com/terraform-google-modules/terraform-example-foundation) using terraform modules from the [Cloud Foundation Toolkit](https://cloud.google.com/foundation-toolkit).
+The deployment terraform files used to deploy the environments are located in the [deployment folder](https://github.com/canada-ca/accelerators_accelerateurs-gcp/tree/main/deployment-templates/Terraform/guardrails/) and are based off of the [example organization](https://github.com/terraform-google-modules/terraform-example-foundation) using terraform modules from the [Cloud Foundation Toolkit](https://cloud.google.com/foundation-toolkit).
 
 To deploy the environment please follow the processes outlined in the deployment [README](deployment-templates/Terraform/guardrails/README.md)
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 # GC Accelerators (GCP)
 
-[![Open this project in Google Cloud Shell](http://gstatic.com/cloudssh/images/open-btn.png)](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/fmichaelobrien/accelerators_accelerateurs-gcp&page=editor&tutorial=README.md)
+[![Open this project in Google Cloud Shell](http://gstatic.com/cloudssh/images/open-btn.png)](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/canada-ca/accelerators_accelerateurs-gcp&page=editor&tutorial=README.md)
 
 This repository will host the required tooling for deploying a basic GCP environment to be conformant with the the Government of Canada's [Cloud Guardrails Framework](https://github.com/canada-ca/cloud-guardrails).
 

--- a/deployment-templates/Terraform/guardrails/1-guardrails/org-policy.tf
+++ b/deployment-templates/Terraform/guardrails/1-guardrails/org-policy.tf
@@ -17,3 +17,19 @@ module "org-policy" {
   policy_for = "organization"
 }
 
+/************************
+Restrict the Public Marketplace
+https://github.com/canada-ca/cloud-guardrails/blob/master/EN/12_Cloud-Marketplace-Config.md
+via
+https://registry.terraform.io/modules/terraform-google-modules/org-policy/google/latest
+************************/
+module "org-policy-mkt" {
+  source  = "terraform-google-modules/org-policy/google"
+  version = "~> 3.0.2"
+
+  constraint        = "constraints/commerceorggovernance.disablePublicMarketplace"
+  policy_type       = "boolean"
+  organization_id   = var.org_id
+  enforce           = true
+  policy_for = "organization"
+}

--- a/deployment-templates/Terraform/guardrails/README.md
+++ b/deployment-templates/Terraform/guardrails/README.md
@@ -133,12 +133,12 @@ The information that is pre-populated is just placeholder information. Change th
 ##### Example variables.tfvar
 Note the dept prefix was sgz via a previous ` ./bootstrap.sh -d sgz -p gr-bootstrap-sgz`
 ```
-audit_data_users="postmaster@staging.gcp.zone"
-ssc_broker_users="postmaster@staging.gcp.zone"
-org_id="221....1076"
+audit_data_users="postmaster@domain.com"
+ssc_broker_users="postmaster@domain.com"
+org_id="221....9996"
 terraform_service_account="tfadmin-sgz@sgz-seed-project.iam.gserviceaccount.com"
-billing_account="01A9CE-4....6-B44C11"
-billing_data_users="postmaster@staging.gcp.zone"
+billing_account="99A9CE-4....6-B44C99"
+billing_data_users="postmaster@domain.com"
 audit_logs_table_delete_contents_on_destroy=true
 log_export_storage_force_destroy=true
 allowed_regions=["northamerica-northeast1", "northamerica-northeast2"]


### PR DESCRIPTION
This is the IAM org policy to disable the public marketplace - in addition to the existing evidence around paid services are n/a without the "Billing Account Administrator" role
see security controls in https://github.com/GoogleCloudPlatform/pbmm-on-gcp-onboarding/blob/main/docs/google-cloud-security-controls.md#12-configuration-of-cloud-marketplaces